### PR TITLE
fix: using empty ident

### DIFF
--- a/core/src/eval.rs
+++ b/core/src/eval.rs
@@ -643,6 +643,14 @@ fn eval_binary_expr_node(
                         return Ok(Value::Assignment(Box::new(right_value)));
                     }
 
+                    Node::EmptyIdentifier { .. } => {
+                        // right operand node must evaluate to a value
+                        let mut r = right_operand.as_ref().clone();
+                        _ = r.eval(ctx, stack, false)?;
+
+                        return Ok(Value::Empty);
+                    }
+
                     Node::IndexingOp { operand, index, .. } => {
                         let mut operand = operand.as_ref().clone();
                         match operand.eval(ctx, stack, false)? {

--- a/core/src/runtime.rs
+++ b/core/src/runtime.rs
@@ -224,7 +224,7 @@ impl Context {
 
     /// Allows to Exec() a program file in a given context.
     pub fn exec_path(&mut self, speak: &str, path: &str) -> Result<Value, Err> {
-        match fs::read(path.clone()) {
+        match fs::read(path) {
             Ok(data) => {
                 self.file = Some(path.to_string());
                 let (val, _, _) = self.exec(speak, BufReader::new(&data[..]))?;


### PR DESCRIPTION
Closes: https://github.com/speak-lang/speak/issues/14

Speak programs evaluate expressions, feature was added to prevent this evaluation and return an empty value in the case that we only needed the side-effect of the invocation on the RHS.